### PR TITLE
Integration help

### DIFF
--- a/mr-plonky2-circuits/src/api.rs
+++ b/mr-plonky2-circuits/src/api.rs
@@ -317,11 +317,11 @@ where
                 .generate_proof(inputs, &self.query_circuit_set),
         }?;
         if !is_revelation {
+            Ok(query_proof.to_vec())
+        } else {
             let query_proof = ProofWithVK::deserialize(&query_proof)?;
             self.wrap_circuit
                 .generate_proof(&self.query_circuit_set, &query_proof)
-        } else {
-            Ok(query_proof.to_vec())
         }
     }
     /// Circuit data for the final query proof being returned by `generate_proof`

--- a/mr-plonky2-circuits/src/query_erc20/api.rs
+++ b/mr-plonky2-circuits/src/query_erc20/api.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 pub use super::block::CircuitInput as BlockCircuitInput;
-pub use super::revelation::RevelationRecursiveInput;
+pub use super::revelation::RevelationErcInput;
 pub use super::state::CircuitInput as StateCircuitInput;
 pub use super::storage::CircuitInput as StorageCircuitInput;
 
@@ -18,6 +18,7 @@ use plonky2::{
 use recursion_framework::framework::RecursiveCircuits;
 use serde::{Deserialize, Serialize};
 
+use crate::query_erc20::revelation::RevelationRecursiveInput;
 use anyhow::Result;
 
 /// L is the number of elements we allow to expose in the result

--- a/mr-plonky2-circuits/src/query_erc20/mod.rs
+++ b/mr-plonky2-circuits/src/query_erc20/mod.rs
@@ -7,5 +7,6 @@ mod storage;
 mod tests;
 
 pub use api::{
-    BlockCircuitInput, CircuitInput, PublicParameters, StateCircuitInput, StorageCircuitInput,
+    BlockCircuitInput, CircuitInput, PublicParameters, RevelationErcInput, StateCircuitInput,
+    StorageCircuitInput,
 };


### PR DESCRIPTION
```shell
2024-06-15T11:57:57.629450Z ERROR lgn_worker::tests: Panic occurred: PanicInfo { payload: Any { .. }, message: None, location: Location { file: "/Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/itertools-0.11.0/src/zip_eq_impl.rs", line: 48, col: 13 }, can_unwind: true, force_no_backtrace: false }
2024-06-15T11:57:57.629475Z ERROR lgn_worker::tests: Backtrace:    0: backtrace::backtrace::libunwind::trace
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/libunwind.rs:116:5
      backtrace::backtrace::trace_unsynchronized
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/backtrace/mod.rs:53:14
   2: backtrace::capture::Backtrace::create
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:197:9
   3: backtrace::capture::Backtrace::new
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:162:22
   4: lgn_worker::tests::test_ecr20_query::{{closure}}
             at /Users/andrussalumets/IdeaProjects/lgn-coprocessor/lgn-worker/src/main.rs:321:29
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/8c127df75fde3d5ad8ef9af664962a7676288b52/library/alloc/src/boxed.rs:2036:9
      std::panicking::rust_panic_with_hook
             at /rustc/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/panicking.rs:799:13
   6: std::panicking::begin_panic::{{closure}}
             at /rustc/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/panicking.rs:694:9
   7: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/sys_common/backtrace.rs:171:18
   8: std::panicking::begin_panic
             at /rustc/8c127df75fde3d5ad8ef9af664962a7676288b52/library/std/src/panicking.rs:693:12
   9: <itertools::zip_eq_impl::ZipEq<I,J> as core::iter::traits::iterator::Iterator>::next
             at /Users/andrussalumets/.cargo/registry/src/index.crates.io-6f17d22bba15001f/itertools-0.11.0/src/zip_eq_impl.rs:48:13
  10: plonky2::iop::witness::WitnessWrite::set_proof_with_pis_target
             at /Users/andrussalumets/.cargo/git/checkouts/plonky2-d7af43da6a6cacbf/ff04ad3/plonky2/src/iop/witness.rs:90:29
  11: recursion_framework::universal_verifier_gadget::verifier_gadget::UniversalVerifierTarget<_>::set_target
             at /Users/andrussalumets/IdeaProjects/Euclid-database/recursion-framework/src/universal_verifier_gadget/verifier_gadget.rs:75:9
  12: recursion_framework::framework::RecursiveCircuitsVerifierTarget<_>::set_target
             at /Users/andrussalumets/IdeaProjects/Euclid-database/recursion-framework/src/framework.rs:166:9
  13: mr_plonky2_circuits::api::WrapCircuitParams<_>::generate_proof
             at /Users/andrussalumets/IdeaProjects/Euclid-database/mr-plonky2-circuits/src/api.rs:254:9
  14: mr_plonky2_circuits::api::QueryParameters<_,_>::generate_proof
             at /Users/andrussalumets/IdeaProjects/Euclid-database/mr-plonky2-circuits/src/api.rs:321:13
  15: <lgn_provers::provers::v0::query::erc20::prover::EuclidProver as lgn_provers::provers::v0::query::erc20::prover::QueryProver>::prove_storage_leaf
             at /Users/andrussalumets/IdeaProjects/lgn-coprocessor/lgn-provers/src/provers/v0/query/erc20/prover.rs:72:21
  16: lgn_provers::provers::v0::query::erc20::task::Query<P>::process_task
             at /Users/andrussalumets/IdeaProjects/lgn-coprocessor/lgn-provers/src/provers/v0/query/erc20/task.rs:50:33
  17: lgn_provers::provers::v0::query::erc20::task::Query<P>::run_inner
             at /Users/andrussalumets/IdeaProjects/lgn-coprocessor/lgn-provers/src/provers/v0/query/erc20/task.rs:34:25
  18: <lgn_provers::provers::v0::query::erc20::task::Query<P> as lgn_provers::provers::LgnProver>::run
             at /Users/andrussalumets/IdeaProjects/lgn-coprocessor/lgn-provers/src/provers/v0/query/erc20/task.rs:20:9
  19: lgn_worker::tests::test_ecr20_query
```