### PR TITLE
Fix typos

### DIFF
--- a/gnark-utils/lib/lib.go
+++ b/gnark-utils/lib/lib.go
@@ -3,7 +3,7 @@
 // - It's a pending PR, will loss the commit if it's rebased or merged.
 // - It's build with a tool of command line which only operates via files. But
 //   we want to call proving and verifying as functions with string arguments.
-// - We want to use Go as functions not a seprate process (or thread). Since it
+// - We want to use Go as functions not a separate process (or thread). Since it
 //   could handle concurrent easily for the proving and verifying processes.
 
 package main

--- a/groth16-framework/src/evm/executor.rs
+++ b/groth16-framework/src/evm/executor.rs
@@ -7,7 +7,7 @@ use revm::{
     InMemoryDB, EVM,
 };
 
-/// Deploy contract and then call with calldata.
+/// Deploy the contract and then call with calldata.
 /// Return the gas_used and the output bytes of call to deployed contract if
 /// both transactions are successful.
 pub fn deploy_and_call(deployment_code: Vec<u8>, calldata: Vec<u8>) -> Result<(u64, Vec<u8>)> {

--- a/groth16-framework/src/lib.rs
+++ b/groth16-framework/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! 3. Prove the normal proofs of mapreduce-plonky2
 //!
-//!    This proving step could be called for mulitple times to generate the
+//!    This proving step could be called for multiple times to generate the
 //!    Groth16 proofs. It's called as below.
 //!
 //!    ``

--- a/groth16-framework/test_data/query2.sol
+++ b/groth16-framework/test_data/query2.sol
@@ -73,7 +73,7 @@ contract Query2 is Verifier {
         // 3. Assert the hash of plonky2 public inputs must be equal to the last Groth16 input.
         verifyPlonky2Inputs(pis, groth16_inputs);
 
-        // 3. Asset the query in plonky2 public inputs must be equal to expected `query` argument.
+        // 3. Asset the query in plonky2 public inputs must be equal to the expected `query` argument.
         verifyQuery(pis, query);
 
         // 4. Parse and return the NFT IDs.

--- a/groth16-framework/test_data/query2_verifier.sol
+++ b/groth16-framework/test_data/query2_verifier.sol
@@ -151,7 +151,7 @@ contract Verifier {
     }
 
     /// Square test in Fp.
-    /// @notice Returns wheter a number x exists such that x * x = a in Fp.
+    /// @notice Returns whether a number x exists such that x * x = a in Fp.
     /// @notice Will revert with InvalidProof() if the input is not a square
     /// or not reduced.
     /// @param a the square


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.



Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.


Best regards.